### PR TITLE
regexp in mountpoint

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -12,7 +12,8 @@ define autofs::mount ($remote, $mountpoint, $options = '', $mapname = undef) {
     fail("Autofs::Mount options string must start with -, and not contain spaces. Got: ${options}")
   }
 
-  if dirname($mountpoint) == '/' {
+  if $mountpoint =~ /^[\/]([[0-9a-zA-Z\.\/_\s-]]*)*[\/]$/ {
+
     $dirname = '/-'
     $basename = $mountpoint
   } else {


### PR DESCRIPTION
Currently there is no possibility to use /- in mount_entries
that will allow fot all paths staring from "/" and ending "/" to be servicesd by "/-" entry in auto/master